### PR TITLE
Fixed API version

### DIFF
--- a/SitecoreDeployer/buildtask/functions-module-v1.psm1
+++ b/SitecoreDeployer/buildtask/functions-module-v1.psm1
@@ -221,7 +221,9 @@ function SetWebAppRestrictions {
     }
 
     #get API version to work with Azure Web apps
-    $APIVersion = ((Get-AzureRmResourceProvider -ProviderNamespace Microsoft.Web).ResourceTypes | Where-Object ResourceTypeName -eq sites).ApiVersions[0];
+    #$APIVersion = ((Get-AzureRmResourceProvider -ProviderNamespace Microsoft.Web).ResourceTypes | Where-Object ResourceTypeName -eq sites).ApiVersions[0];
+    #in latest APIVerions (2018-02-01) - something changed on setting web app IP restrictions, so, I will use the last, where this code executes OK
+    $APIVersion = "2016-08-01";
     #by default, we are supposing we are working with slots
     $isSlot = $false
     #if instance name does not contain / - it is not a slot :)


### PR DESCRIPTION
In latest version of API exposed (2018-02-01 at time of this issue) - ipRestrictions on web app are set in another way, which is still seems not to be documented (at least, there is no Powershell example at https://docs.microsoft.com/en-gb/azure/app-service/app-service-ip-restrictions and there is a documentation PR opened - https://github.com/MicrosoftDocs/azure-docs/issues/9432 )
This fix hardcodes API version at 2016-08-01 - where it do works